### PR TITLE
Add b2n.ir, discount-package, and activation spam blocklists

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.miss.ga"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2
-        versionName = "1.0.1"
+        versionCode = 3
+        versionName = "1.0.2"
     }
 
     signingConfigs {

--- a/app/src/main/java/com/miss/ga/data/model/PredefinedRules.kt
+++ b/app/src/main/java/com/miss/ga/data/model/PredefinedRules.kt
@@ -298,6 +298,42 @@ object PredefinedRules {
                 category = RuleCategory.SPAM_KEYWORD,
                 description = "Operator/app ads that push in-app purchases (خرید از اپلیکیشن)"
             ),
+            FilterRule(
+                id = -22,
+                name = "b2n.ir Short Links",
+                pattern = "(?i)(https?://)?([a-z0-9-]+\\.)*b2n\\.ir",
+                isRegex = true,
+                action = FilterAction.SPAM,
+                listType = RuleListType.BLOCKLIST,
+                isEnabled = true,
+                isPredefined = true,
+                category = RuleCategory.SPAM_KEYWORD,
+                description = "Blocks b2n.ir shortened links in any casing (b2n.ir / B2N.IR / https://b2n.ir/...)"
+            ),
+            FilterRule(
+                id = -23,
+                name = "Discount Packages (بسته‌های تخفیفی)",
+                pattern = "بسته\\s*های\\s*تخفیفی",
+                isRegex = true,
+                action = FilterAction.SPAM,
+                listType = RuleListType.BLOCKLIST,
+                isEnabled = true,
+                isPredefined = true,
+                category = RuleCategory.SPAM_KEYWORD,
+                description = "Promotional discount-package ads: بسته‌های تخفیفی / بسته های تخفیفی"
+            ),
+            FilterRule(
+                id = -24,
+                name = "Activation Keyword (فعالسازی)",
+                pattern = "فعال\\s*سازی",
+                isRegex = true,
+                action = FilterAction.SPAM,
+                listType = RuleListType.BLOCKLIST,
+                isEnabled = true,
+                isPredefined = true,
+                category = RuleCategory.SPAM_KEYWORD,
+                description = "Blocks the word فعالسازی in every common spelling: فعالسازی, فعال سازی, فعال‌سازی"
+            ),
 
             // ==========================================
             // --- SERVICE ALLOWLIST PRESETS ---

--- a/app/src/test/java/com/miss/ga/SmsFilterEngineTest.kt
+++ b/app/src/test/java/com/miss/ga/SmsFilterEngineTest.kt
@@ -161,7 +161,10 @@ class SmsFilterEngineTest {
             -18L to "فعال‌سازی از طریق کد دستوری #۱۲۳* انجام شود.",
             -19L to "پیش‌بینی هوای فردا: بارانی. بسته اینترنت هدیه فعال کنید.",
             -20L to "عضو کانال شوید: https://rubika.ir/joinc/abc123",
-            -21L to "خرید از اپلیکیشن با تخفیف ویژه فقط تا امشب."
+            -21L to "خرید از اپلیکیشن با تخفیف ویژه فقط تا امشب.",
+            -22L to "برای دریافت جایزه روی لینک کلیک کنید: https://b2n.ir/abc123",
+            -23L to "بسته‌های تخفیفی اینترنت همراه اول برای شما فعال شد.",
+            -24L to "جهت فعالسازی بسته عدد ۱ را ارسال کنید."
         )
 
         cases.forEach { (id, sample) ->
@@ -233,6 +236,61 @@ class SmsFilterEngineTest {
                 SmsFilterEngine.testPattern(rule.pattern, rule.isRegex, personal).isMatch
             )
         }
+
+        val b2nRule = PredefinedRules.getDefaultRules().first { it.id == -22L }
+        listOf(
+            "https://B2N.IR/promo",
+            "http://www.b2n.ir/abc",
+            "B2n.Ir/xyz",
+            "b2n.ir"
+        ).forEach { sample ->
+            assertTrue(
+                "b2n.ir variant should match case-insensitively: $sample",
+                SmsFilterEngine.testPattern(b2nRule.pattern, true, sample).isMatch
+            )
+        }
+
+        val discountPackagesRule = PredefinedRules.getDefaultRules().first { it.id == -23L }
+        listOf(
+            "بسته‌های تخفیفی ویژه",
+            "بسته های تخفیفی ویژه",
+            "بسته\u200Cهای تخفیفی ویژه"
+        ).forEach { sample ->
+            assertTrue(
+                "Discount-package variant should match: $sample",
+                SmsFilterEngine.testPattern(discountPackagesRule.pattern, true, sample).isMatch
+            )
+        }
+
+        val activationRule = PredefinedRules.getDefaultRules().first { it.id == -24L }
+        listOf(
+            "فعالسازی بسته",
+            "فعال سازی بسته",
+            "فعال‌سازی بسته",
+            "فعال\u200Cسازی بسته"
+        ).forEach { sample ->
+            assertTrue(
+                "Activation-keyword variant should match: $sample",
+                SmsFilterEngine.testPattern(activationRule.pattern, true, sample).isMatch
+            )
+        }
+    }
+
+    @Test
+    fun testActivationOtpStillAllowlistedOverActivationKeywordBlocklist() {
+        val otpSms = "کد فعالسازی حساب کاربری: 554201"
+        val result = SmsFilterEngine.evaluateMessage(
+            sender = "10001234",
+            body = otpSms,
+            rules = PredefinedRules.getDefaultRules(),
+            senderPreference = null
+        )
+        assertEquals(
+            "OTP allowlist must override the فعالسازی keyword blocklist",
+            FilterAction.NORMAL,
+            result.action
+        )
+        assertTrue(result.isAllowlisted)
     }
 
     @Test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ships three new predefined blocklist presets and bumps the app to **1.0.2**.

## Changes
- **b2n.ir** (case-insensitive): blocks shortened `b2n.ir` links in any casing, including `https://B2N.IR/...` and `www.b2n.ir`.
- **بسته‌های تخفیفی**: blocks discount-package promo copy, including ZWNJ / spaced spellings.
- **فعالسازی**: blocks the activation keyword in common spellings (`فعالسازی`, `فعال سازی`, `فعال‌سازی`). OTP allowlist still wins, so verification codes such as `کد فعالسازی` continue to be delivered.
- Version bump: `versionName` `1.0.1` → `1.0.2`, `versionCode` `2` → `3`.
- Unit tests cover the new presets, casing/ZWNJ variants, and OTP-over-blocklist priority.

Existing installs pick up the new presets through the existing predefined-rule sync on database open.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ed34fb0-0319-4ce5-85ec-8b80f6c95878?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ed34fb0-0319-4ce5-85ec-8b80f6c95878&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

