### PR TITLE
Add pre-release workflow that publishes signed APKs as prereleases

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,107 @@
+name: Pre-release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+-pre"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pre-release
+  cancel-in-progress: false
+
+jobs:
+  pre-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read app version
+        id: version
+        run: |
+          VERSION=$(sed -nE 's/^[[:space:]]*versionName = "([^"]+)".*/\1/p' app/build.gradle.kts)
+          if [[ -z "$VERSION" ]]; then
+            echo "::error::Could not read versionName from app/build.gradle.kts"
+            exit 1
+          fi
+          if [[ "$VERSION" == v* ]]; then
+            echo "::error::versionName must not include a 'v' prefix (got $VERSION)"
+            exit 1
+          fi
+          TAG="${VERSION}-pre"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "App version is $VERSION (pre-release tag $TAG)"
+
+      - name: Ensure git tag matches versionName-pre
+        if: github.ref_type == 'tag'
+        run: |
+          if [[ "${{ github.ref_name }}" != "${{ steps.version.outputs.tag }}" ]]; then
+            echo "::error::Git tag ${{ github.ref_name }} must equal ${{ steps.version.outputs.tag }}"
+            exit 1
+          fi
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Decode signing keystore
+        env:
+          SIGNING_KEYSTORE: ${{ secrets.SIGNING_KEYSTORE }}
+        run: |
+          if [[ -z "$SIGNING_KEYSTORE" ]]; then
+            echo "::error::SIGNING_KEYSTORE secret is missing"
+            exit 1
+          fi
+          echo "$SIGNING_KEYSTORE" | tr -d '\n\r ' | base64 --decode > "$RUNNER_TEMP/misga-release.jks"
+          test -s "$RUNNER_TEMP/misga-release.jks"
+
+      - name: Build signed release APK
+        env:
+          SIGNING_STORE_FILE: ${{ runner.temp }}/misga-release.jks
+          SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        run: ./gradlew assembleRelease --stacktrace
+
+      - name: Verify APK is signed
+        run: |
+          APKSIGNER=$(find "$ANDROID_HOME/build-tools" -name apksigner | sort | tail -1)
+          SIGNED="app/build/outputs/apk/release/app-release.apk"
+          UNSIGNED="app/build/outputs/apk/release/app-release-unsigned.apk"
+          if [[ -f "$UNSIGNED" && ! -f "$SIGNED" ]]; then
+            echo "::error::Release APK was not signed. Check signing secrets."
+            exit 1
+          fi
+          test -f "$SIGNED"
+          "$APKSIGNER" verify --verbose "$SIGNED"
+
+      - name: Prepare release artifacts
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          mkdir -p dist
+          cp app/build/outputs/apk/release/app-release.apk "dist/misga-${TAG}-universal.apk"
+          sha256sum dist/*.apk | tee dist/SHA256SUMS
+
+      - name: Publish GitHub Pre-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes \
+            --prerelease \
+            --latest=false \
+            "dist/misga-${TAG}-universal.apk" \
+            dist/SHA256SUMS


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a **Pre-release** workflow that mirrors `release.yml`: same signed universal APK build, same keystore secrets, same version check against `versionName`.

The difference is how the GitHub Release is published:

- Tag is `{versionName}-pre` (for example `1.0.2-pre`) so it does not collide with the stable `1.0.2` release
- `gh release create` uses `--prerelease --latest=false`, so GitHub marks it as a pre-release and does **not** set it as Latest

## How to run it

- **Actions → Pre-release → Run workflow**, or
- Push a tag matching `X.Y.Z-pre` that equals `versionName` plus `-pre`

Stable releases stay on `release.yml` (`X.Y.Z` tags, Latest).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ed34fb0-0319-4ce5-85ec-8b80f6c95878?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ed34fb0-0319-4ce5-85ec-8b80f6c95878&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

