### PR TITLE
Add blocklist preset for رُند in any shape

### DIFF
--- a/app/src/main/java/com/miss/ga/data/model/PredefinedRules.kt
+++ b/app/src/main/java/com/miss/ga/data/model/PredefinedRules.kt
@@ -334,6 +334,18 @@ object PredefinedRules {
                 category = RuleCategory.SPAM_KEYWORD,
                 description = "Blocks the word فعالسازی in every common spelling: فعالسازی, فعال سازی, فعال‌سازی"
             ),
+            FilterRule(
+                id = -25,
+                name = "Vanity Number Promo (رُند)",
+                pattern = "(?<![\\u0600-\\u06FF])ر\\s*ن\\s*د(?![\\u0600-\\u06FF])",
+                isRegex = true,
+                action = FilterAction.SPAM,
+                listType = RuleListType.BLOCKLIST,
+                isEnabled = true,
+                isPredefined = true,
+                category = RuleCategory.SPAM_KEYWORD,
+                description = "Blocks the standalone word رُند in any shape: رند, رُند, ر ند, ر‌ند. Does not match برند."
+            ),
 
             // ==========================================
             // --- SERVICE ALLOWLIST PRESETS ---

--- a/app/src/test/java/com/miss/ga/SmsFilterEngineTest.kt
+++ b/app/src/test/java/com/miss/ga/SmsFilterEngineTest.kt
@@ -164,7 +164,8 @@ class SmsFilterEngineTest {
             -21L to "خرید از اپلیکیشن با تخفیف ویژه فقط تا امشب.",
             -22L to "برای دریافت جایزه روی لینک کلیک کنید: https://b2n.ir/abc123",
             -23L to "بسته‌های تخفیفی اینترنت همراه اول برای شما فعال شد.",
-            -24L to "جهت فعالسازی بسته عدد ۱ را ارسال کنید."
+            -24L to "جهت فعالسازی بسته عدد ۱ را ارسال کنید.",
+            -25L to "شماره رُند ویژه با قیمت استثنایی."
         )
 
         cases.forEach { (id, sample) ->
@@ -272,6 +273,31 @@ class SmsFilterEngineTest {
             assertTrue(
                 "Activation-keyword variant should match: $sample",
                 SmsFilterEngine.testPattern(activationRule.pattern, true, sample).isMatch
+            )
+        }
+
+        val rondRule = PredefinedRules.getDefaultRules().first { it.id == -25L }
+        listOf(
+            "شماره رند",
+            "شماره رُند",
+            "شماره رُنْد",
+            "خط ر ند",
+            "سیم‌کارت ر\u200Cند",
+            "رــند موجود",
+            "رند."
+        ).forEach { sample ->
+            assertTrue(
+                "رُند variant should match: $sample",
+                SmsFilterEngine.testPattern(rondRule.pattern, true, sample).isMatch
+            )
+        }
+        listOf(
+            "برند جدید دیجی‌کالا",
+            "فرزندم زنگ زد"
+        ).forEach { sample ->
+            assertFalse(
+                "Substring lookalike must not match رُند: $sample",
+                SmsFilterEngine.testPattern(rondRule.pattern, true, sample).isMatch
             )
         }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a shipped blocklist preset for the standalone word **رُند** (vanity / “rond” phone-number ads).

The pattern matches the word in any common shape:

- رند
- رُند / رُنْد (diacritics are stripped)
- ر ند (spaces)
- ر‌ند (ZWNJ)
- رــند (tatweel / kashida)

It is a whole-word match, so lookalikes such as **برند** are not flagged.

Existing installs pick up the new preset through the predefined-rule sync on database open.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ed34fb0-0319-4ce5-85ec-8b80f6c95878?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ed34fb0-0319-4ce5-85ec-8b80f6c95878&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

