### PR TITLE
Allowlist بابت لغو سفارش refunds and bump to 1.0.6

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.miss.ga"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6
-        versionName = "1.0.5"
+        versionCode = 7
+        versionName = "1.0.6"
     }
 
     signingConfigs {

--- a/app/src/main/java/com/miss/ga/data/model/PredefinedRules.kt
+++ b/app/src/main/java/com/miss/ga/data/model/PredefinedRules.kt
@@ -361,6 +361,18 @@ object PredefinedRules {
                 isPredefined = true,
                 category = RuleCategory.CUSTOM_ALLOWLIST,
                 description = "Operator notices about remaining package validity / usage deadline — delivered with alert, overriding blocklists"
+            ),
+            FilterRule(
+                id = -105,
+                name = "Order Cancellation Refund (بابت لغو سفارش)",
+                pattern = "بابت\\s*لغو\\s*سفارش",
+                isRegex = true,
+                action = FilterAction.NORMAL,
+                listType = RuleListType.ALLOWLIST,
+                isEnabled = true,
+                isPredefined = true,
+                category = RuleCategory.CUSTOM_ALLOWLIST,
+                description = "Payment-app refund notices for a cancelled order (بابت لغو سفارش) — delivered with alert, overriding promo keywords such as فعال‌سازی"
             )
         )
     }

--- a/app/src/test/java/com/miss/ga/SmsFilterEngineTest.kt
+++ b/app/src/test/java/com/miss/ga/SmsFilterEngineTest.kt
@@ -348,4 +348,36 @@ class SmsFilterEngineTest {
         )
         assertTrue(result.isAllowlisted)
     }
+
+    @Test
+    fun testOrderCancellationRefundAllowlistPreset() {
+        val rule = PredefinedRules.getDefaultRules().first { it.id == -105L }
+        val snappPaySms = """کاربر عزیز اسنپ‌پی،
+مبلغ ۸,۸۷۶,۰۸۸ تومان، بابت لغو سفارش، به کیف پول‌تان عودت داده شد.
+با فعال‌سازی قابلیت جدید «دریافت سود» روی موجودی کیف‌ پولتان سود دریافت کنید.
+مشاهده موجودی و فعال‌سازی دریافت سود: https://l.snpy.ir/wqbxd"""
+        val zwnjSms = "مبلغ به کیف پول بابت\u200Cلغو سفارش عودت داده شد."
+
+        assertTrue(
+            "Expected بابت لغو سفارش refund notice to match allowlist",
+            SmsFilterEngine.testPattern(rule.pattern, true, snappPaySms).isMatch
+        )
+        assertTrue(
+            "ZWNJ form of بابت لغو سفارش should still match",
+            SmsFilterEngine.testPattern(rule.pattern, true, zwnjSms).isMatch
+        )
+
+        val result = SmsFilterEngine.evaluateMessage(
+            sender = "10008899",
+            body = snappPaySms,
+            rules = PredefinedRules.getDefaultRules(),
+            senderPreference = null
+        )
+        assertEquals(
+            "بابت لغو سفارش allowlist must override فعالسازی keyword blocklist",
+            FilterAction.NORMAL,
+            result.action
+        )
+        assertTrue(result.isAllowlisted)
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a shipped allowlist preset for **بابت لغو سفارش** so payment-app refund notices stay delivered with a normal alert.

Those messages are otherwise silenced by the **فعالسازی** blocklist. Example (Snapp Pay):

> کاربر عزیز اسنپ‌پی،
> مبلغ ۸,۸۷۶,۰۸۸ تومان، بابت لغو سفارش، به کیف پول‌تان عودت داده شد.
> با فعال‌سازی قابلیت جدید «دریافت سود» …

Allowlist still wins over keyword and shortcode blocklists. The pattern also matches ZWNJ spellings such as `بابت‌لغو سفارش`.

App version: **1.0.5 → 1.0.6** (`versionCode` 6 → 7).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ed34fb0-0319-4ce5-85ec-8b80f6c95878?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ed34fb0-0319-4ce5-85ec-8b80f6c95878&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

