### PR TITLE
Allowlist مرسوله shipment notices

### DIFF
--- a/app/src/main/java/com/miss/ga/data/model/PredefinedRules.kt
+++ b/app/src/main/java/com/miss/ga/data/model/PredefinedRules.kt
@@ -373,6 +373,18 @@ object PredefinedRules {
                 isPredefined = true,
                 category = RuleCategory.CUSTOM_ALLOWLIST,
                 description = "Payment-app refund notices for a cancelled order (بابت لغو سفارش) — delivered with alert, overriding promo keywords such as فعال‌سازی"
+            ),
+            FilterRule(
+                id = -106,
+                name = "Shipment Notice (مرسوله)",
+                pattern = "مرسوله",
+                isRegex = true,
+                action = FilterAction.NORMAL,
+                listType = RuleListType.ALLOWLIST,
+                isEnabled = true,
+                isPredefined = true,
+                category = RuleCategory.CUSTOM_ALLOWLIST,
+                description = "Shop/courier shipment notices (مرسوله) — delivered with alert, overriding opt-out keywords such as لغو 11"
             )
         )
     }

--- a/app/src/test/java/com/miss/ga/SmsFilterEngineTest.kt
+++ b/app/src/test/java/com/miss/ga/SmsFilterEngineTest.kt
@@ -380,4 +380,36 @@ class SmsFilterEngineTest {
         )
         assertTrue(result.isAllowlisted)
     }
+
+    @Test
+    fun testShipmentNoticeAllowlistPreset() {
+        val rule = PredefinedRules.getDefaultRules().first { it.id == -106L }
+        val snappShopSms = """اسنپ شاپ
+مرسوله 1 از سفارش 673984966 کنسل شد. 
+اعتبار خرید تا ۲ساعت آینده اصلاح و مبلغ پرداختی شما تا ۲۴ساعت آینده به کیف پول اسنپ‌پی یا کارت پرداختی واریز میشود.
+لغو 11"""
+        val zwnjSms = "مرسوله\u200Cی سفارش شما ارسال شد."
+
+        assertTrue(
+            "Expected مرسوله shipment notice to match allowlist",
+            SmsFilterEngine.testPattern(rule.pattern, true, snappShopSms).isMatch
+        )
+        assertTrue(
+            "ZWNJ form of مرسوله should still match",
+            SmsFilterEngine.testPattern(rule.pattern, true, zwnjSms).isMatch
+        )
+
+        val result = SmsFilterEngine.evaluateMessage(
+            sender = "10001234",
+            body = snappShopSms,
+            rules = PredefinedRules.getDefaultRules(),
+            senderPreference = null
+        )
+        assertEquals(
+            "مرسوله allowlist must override لغو 11 opt-out blocklist",
+            FilterAction.NORMAL,
+            result.action
+        )
+        assertTrue(result.isAllowlisted)
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a shipped allowlist preset for the word **مرسوله** so shop/courier shipment notices stay delivered with a normal alert.

Those messages are otherwise silenced by the **لغو 11** opt-out blocklist. Example (Snapp Shop):

> اسنپ شاپ
> مرسوله 1 از سفارش 673984966 کنسل شد.
> …
> لغو 11

Allowlist still wins over keyword and shortcode blocklists.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ed34fb0-0319-4ce5-85ec-8b80f6c95878?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ed34fb0-0319-4ce5-85ec-8b80f6c95878&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

