### PR TITLE
Block l.snpy.ir Snapp Pay promo short links

### DIFF
--- a/app/src/main/java/com/miss/ga/data/model/PredefinedRules.kt
+++ b/app/src/main/java/com/miss/ga/data/model/PredefinedRules.kt
@@ -346,6 +346,18 @@ object PredefinedRules {
                 category = RuleCategory.SPAM_KEYWORD,
                 description = "Blocks the standalone word رُند in any shape: رند, رُند, ر ند, ر‌ند. Does not match برند."
             ),
+            FilterRule(
+                id = -26,
+                name = "Snapp Pay Short Links (l.snpy.ir)",
+                pattern = "(?i)(https?://)?([a-z0-9-]+\\.)*l\\.snpy\\.ir",
+                isRegex = true,
+                action = FilterAction.SPAM,
+                listType = RuleListType.BLOCKLIST,
+                isEnabled = true,
+                isPredefined = true,
+                category = RuleCategory.SPAM_KEYWORD,
+                description = "Blocks l.snpy.ir shortened links in any casing (l.snpy.ir / L.SNPY.IR / https://l.snpy.ir/...)"
+            ),
 
             // ==========================================
             // --- SERVICE ALLOWLIST PRESETS ---

--- a/app/src/test/java/com/miss/ga/SmsFilterEngineTest.kt
+++ b/app/src/test/java/com/miss/ga/SmsFilterEngineTest.kt
@@ -165,7 +165,8 @@ class SmsFilterEngineTest {
             -22L to "برای دریافت جایزه روی لینک کلیک کنید: https://b2n.ir/abc123",
             -23L to "بسته‌های تخفیفی اینترنت همراه اول برای شما فعال شد.",
             -24L to "جهت فعالسازی بسته عدد ۱ را ارسال کنید.",
-            -25L to "شماره رُند ویژه با قیمت استثنایی."
+            -25L to "شماره رُند ویژه با قیمت استثنایی.",
+            -26L to "خرید:\nl.snpy.ir/iouvc"
         )
 
         cases.forEach { (id, sample) ->
@@ -300,6 +301,38 @@ class SmsFilterEngineTest {
                 SmsFilterEngine.testPattern(rondRule.pattern, true, sample).isMatch
             )
         }
+
+        val snpyRule = PredefinedRules.getDefaultRules().first { it.id == -26L }
+        listOf(
+            "l.snpy.ir/iouvc",
+            "https://l.snpy.ir/wqbxd",
+            "http://www.l.snpy.ir/abc",
+            "L.SNPY.IR",
+            "L.Snpy.Ir/xyz"
+        ).forEach { sample ->
+            assertTrue(
+                "l.snpy.ir variant should match case-insensitively: $sample",
+                SmsFilterEngine.testPattern(snpyRule.pattern, true, sample).isMatch
+            )
+        }
+        val snpyPromo = """با خرید قسطی، نگران آخر ماه نیستی!
+با اسنپ‌پی، کالاهای مورد نیازت رو آخر ماه، آنلاین و حضوری در ۴قسط بخر.
++ ۲۰۰هزار تومن تخفیف بیشتر با کد PAY2TMH
+کف خرید: ۱میلیون تومن
+خرید:
+l.snpy.ir/iouvc"""
+        val snpyResult = SmsFilterEngine.evaluateMessage(
+            sender = "+989121234567",
+            body = snpyPromo,
+            rules = PredefinedRules.getDefaultRules(),
+            senderPreference = null
+        )
+        assertEquals(
+            "Snapp Pay installment promo with l.snpy.ir must be blocked",
+            FilterAction.SPAM,
+            snpyResult.action
+        )
+        assertFalse(snpyResult.isAllowlisted)
     }
 
     @Test
@@ -374,7 +407,7 @@ class SmsFilterEngineTest {
             senderPreference = null
         )
         assertEquals(
-            "بابت لغو سفارش allowlist must override فعالسازی keyword blocklist",
+            "بابت لغو سفارش allowlist must override فعالسازی and l.snpy.ir blocklists",
             FilterAction.NORMAL,
             result.action
         )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a shipped blocklist preset for **l.snpy.ir** so Snapp Pay promo short links are silenced.

Example that should be marked spam:

> با خرید قسطی، نگران آخر ماه نیستی!
> …
> خرید:
> l.snpy.ir/iouvc

Matching is case-insensitive (`l.snpy.ir`, `L.SNPY.IR`, `https://l.snpy.ir/...`).

Refund notices that already match the **بابت لغو سفارش** allowlist still win and stay delivered, even when they include an `l.snpy.ir` link.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ed34fb0-0319-4ce5-85ec-8b80f6c95878?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ed34fb0-0319-4ce5-85ec-8b80f6c95878&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

