### PR TITLE
Fix empty UNKNOWN SENDER ghost SMS

### DIFF
--- a/app/src/main/java/com/miss/ga/data/repository/SmsRepository.kt
+++ b/app/src/main/java/com/miss/ga/data/repository/SmsRepository.kt
@@ -20,6 +20,7 @@ import com.miss.ga.data.model.SenderPreference
 import com.miss.ga.data.model.SmsMessage
 import com.miss.ga.data.util.PhoneNumberKeys
 import com.miss.ga.engine.FilterRulesCache
+import com.miss.ga.engine.IncomingSmsPolicy
 import com.miss.ga.engine.PreparedFilterRules
 import com.miss.ga.engine.SmsFilterEngine
 import kotlinx.coroutines.Dispatchers
@@ -78,7 +79,10 @@ class SmsRepository(private val context: Context) {
         }
     }
 
-    suspend fun getCachedThreads(): List<ConversationThread> = dbHelper.getCachedThreads()
+    suspend fun getCachedThreads(): List<ConversationThread> =
+        dbHelper.getCachedThreads().filterNot { thread ->
+            IncomingSmsPolicy.isGhostConversation(thread.address, thread.snippet)
+        }
 
     suspend fun saveCachedThreads(threads: List<ConversationThread>) =
         dbHelper.replaceCachedThreads(threads)
@@ -262,6 +266,10 @@ class SmsRepository(private val context: Context) {
                     resolveInboxAction(latest.first, address, latest.second) == FilterAction.SPAM
                 } == true
 
+                if (IncomingSmsPolicy.isGhostConversation(address, row.snippet)) {
+                    continue
+                }
+
                 threads.add(
                     ConversationThread(
                         threadId = threadId,
@@ -353,6 +361,10 @@ class SmsRepository(private val context: Context) {
                     val date = it.getLong(dateIdx)
                     val type = it.getInt(typeIdx)
                     val read = it.getInt(readIdx) == 1
+
+                    if (IncomingSmsPolicy.isGhostConversation(addr, body)) {
+                        continue
+                    }
 
                     val meta = spamMeta[msgId]
                     val isSpam: Boolean
@@ -729,6 +741,10 @@ class SmsRepository(private val context: Context) {
                 while (it.moveToNext() && hits.size < 250) {
                     var threadId = it.getLong(threadIdIdx)
                     val address = it.getString(addrIdx) ?: ""
+                    val body = it.getString(bodyIdx) ?: ""
+                    if (IncomingSmsPolicy.isGhostConversation(address, body)) {
+                        continue
+                    }
                     if (threadId <= 0 && address.isNotBlank()) {
                         threadId = Telephony.Threads.getOrCreateThreadId(context, address)
                     }
@@ -737,7 +753,7 @@ class SmsRepository(private val context: Context) {
                             messageId = it.getLong(idIdx),
                             threadId = threadId,
                             address = address,
-                            body = it.getString(bodyIdx) ?: "",
+                            body = body,
                             date = it.getLong(dateIdx),
                             read = it.getInt(readIdx) == 1,
                             type = it.getInt(typeIdx)

--- a/app/src/main/java/com/miss/ga/engine/IncomingSmsPolicy.kt
+++ b/app/src/main/java/com/miss/ga/engine/IncomingSmsPolicy.kt
@@ -1,0 +1,115 @@
+package com.miss.ga.engine
+
+/**
+ * Decides which incoming PDUs are real user-visible SMS.
+ *
+ * Iranian carriers and some OEMs deliver silent / SIM-toolkit / class-0
+ * "ghost" messages whose originating address is `UNKNOWN_SENDER` (or empty)
+ * and whose body is blank or a placeholder such as `NNNN`. Google Messages
+ * drops those; storing and notifying them produced empty conversations that
+ * disappeared when the user switched default SMS apps.
+ */
+object IncomingSmsPolicy {
+
+    const val TYPE_ZERO_PROTOCOL_ID = 0x40
+
+    /** Address stored when the PDU has no originating address but a real body. */
+    const val STORED_UNKNOWN_ADDRESS = "Unknown"
+
+    fun isUnknownSenderAlias(address: String): Boolean {
+        val normalized = normalizeToken(address)
+        if (normalized.isEmpty()) return true
+        if (normalized in UNKNOWN_SENDER_ALIASES) return true
+        if (normalized.startsWith("unknown_sender")) return true
+        if (normalized.startsWith("unknownsender")) return true
+        return false
+    }
+
+    fun isUnusableBody(body: String): Boolean {
+        val trimmed = body.trim()
+        if (trimmed.isEmpty()) return true
+        val normalized = normalizeToken(trimmed)
+        return normalized.isEmpty() || normalized in PLACEHOLDER_BODIES
+    }
+
+    /**
+     * Returns true when this PDU should be written to the SMS inbox and
+     * (if not spam) notified. Service / silent / empty-unknown messages
+     * return false.
+     */
+    fun shouldKeepInInbox(
+        address: String,
+        body: String,
+        isClassZero: Boolean = false,
+        isTypeZero: Boolean = false,
+        isStatusReport: Boolean = false,
+        isMwiDontStore: Boolean = false
+    ): Boolean {
+        if (isTypeZero || isStatusReport || isMwiDontStore) return false
+        val usableBody = !isUnusableBody(body)
+        if (!usableBody) {
+            // Class-0 flash SMS and unknown/blank senders with no text are
+            // not conversations. Empty bodies from a real number still keep,
+            // matching Google Messages.
+            if (isClassZero || isUnknownSenderAlias(address)) return false
+        }
+        return true
+    }
+
+    fun isGhostConversation(address: String, snippet: String): Boolean {
+        return isUnknownSenderAlias(address) && isUnusableBody(snippet)
+    }
+
+    fun storedAddress(address: String): String {
+        val trimmed = address.trim()
+        return if (trimmed.isEmpty()) STORED_UNKNOWN_ADDRESS else trimmed
+    }
+
+    fun displayName(
+        contactName: String?,
+        address: String,
+        unknownLabel: String
+    ): String {
+        contactName?.takeIf { it.isNotBlank() }?.let { return it }
+        return if (isUnknownSenderAlias(address)) unknownLabel else address
+    }
+
+    private fun normalizeToken(value: String): String {
+        return buildString(value.length) {
+            for (ch in value) {
+                if (ch.isLetterOrDigit()) append(ch.lowercaseChar())
+            }
+        }
+    }
+
+    private val UNKNOWN_SENDER_ALIASES = setOf(
+        "unknown",
+        "unknownsender",
+        "unknownaddress",
+        "unknownnumber",
+        "anonymous",
+        "private",
+        "privatenumber",
+        "restricted",
+        "hidden",
+        "hiddennumber",
+        // Persian "unknown sender" / "hidden number"
+        "فرستندهناشناس",
+        "شمارهمخفی"
+    )
+
+    private val PLACEHOLDER_BODIES = setOf(
+        "n",
+        "nn",
+        "nnn",
+        "nnnn",
+        "na",
+        "nul",
+        "null",
+        "none",
+        "empty",
+        "messagenotfound",
+        "4504",
+        "4504messagenotfound"
+    )
+}

--- a/app/src/main/java/com/miss/ga/engine/NotificationHelper.kt
+++ b/app/src/main/java/com/miss/ga/engine/NotificationHelper.kt
@@ -10,6 +10,7 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.miss.ga.MainActivity
+import com.miss.ga.R
 import com.miss.ga.data.model.FilterAction
 
 class NotificationHelper private constructor(private val context: Context) {
@@ -64,7 +65,8 @@ class NotificationHelper private constructor(private val context: Context) {
         }
 
         val channelId = if (action == FilterAction.NORMAL) CHANNEL_ALERT_ID else CHANNEL_SILENT_ID
-        val displayName = contactName ?: sender
+        val unknownLabel = context.getString(R.string.unknown_sender)
+        val displayName = IncomingSmsPolicy.displayName(contactName, sender, unknownLabel)
         val notificationId = notificationIdFor(threadId)
 
         val openIntent = Intent(context, MainActivity::class.java).apply {

--- a/app/src/main/java/com/miss/ga/receiver/SmsReceiver.kt
+++ b/app/src/main/java/com/miss/ga/receiver/SmsReceiver.kt
@@ -12,6 +12,7 @@ import com.miss.ga.data.db.SpamMetaWrite
 import com.miss.ga.data.model.FilterAction
 import com.miss.ga.data.repository.SmsRepository
 import com.miss.ga.data.util.PhoneNumberKeys
+import com.miss.ga.engine.IncomingSmsPolicy
 import com.miss.ga.engine.NotificationHelper
 import com.miss.ga.engine.SmsFilterEngine
 import kotlin.math.abs
@@ -33,7 +34,14 @@ class SmsReceiver : BroadcastReceiver() {
             return
         }
 
-        val messages = Telephony.Sms.Intents.getMessagesFromIntent(intent)
+        val messages = try {
+            Telephony.Sms.Intents.getMessagesFromIntent(intent)
+                ?.filterNotNull()
+                ?.toTypedArray()
+        } catch (e: Exception) {
+            Log.e(TAG, "Could not parse SMS PDUs", e)
+            return
+        }
         if (messages.isNullOrEmpty()) return
 
         val pendingResult = goAsync()
@@ -68,21 +76,33 @@ class SmsReceiver : BroadcastReceiver() {
         val smsRepository = SmsRepository(context)
 
         // Combine multipart messages by sender
-        val messagesBySender = messages.groupBy { it.displayOriginatingAddress ?: "" }
+        val messagesBySender = messages.groupBy { smsAddress(it) }
         val pendingMetaWrites = mutableListOf<SpamMetaWrite>()
 
-        for ((sender, parts) in messagesBySender) {
-            if (sender.isBlank()) continue
-
-            val fullBody = parts.joinToString(separator = "") { it.displayMessageBody ?: "" }
+        for ((rawSender, parts) in messagesBySender) {
+            val sender = IncomingSmsPolicy.storedAddress(rawSender)
+            val fullBody = parts.joinToString(separator = "") { smsBody(it) }
             val timestamp = parts.firstOrNull()?.timestampMillis ?: System.currentTimeMillis()
+
+            if (!IncomingSmsPolicy.shouldKeepInInbox(
+                    address = sender,
+                    body = fullBody,
+                    isClassZero = parts.any { it.isClassZero() },
+                    isTypeZero = parts.any { it.isTypeZero() },
+                    isStatusReport = parts.any { it.isStatusReport() },
+                    isMwiDontStore = parts.any { it.isMwiDontStoreMessage() }
+                )
+            ) {
+                Log.d(TAG, "Dropping non-inbox SMS from ${PhoneNumberKeys.redact(sender)}")
+                continue
+            }
 
             // Run through the MISGA hierarchical filter engine
             val filterResult = filterEngine.evaluateMessage(sender, fullBody)
 
-            var messageId: Long = System.currentTimeMillis()
+            var messageId: Long = -1L
             var threadId: Long = 0
-            var shouldWriteMeta = false
+            var storedInProvider = false
 
             // If we are the default SMS app and received SMS_DELIVER, we must insert into Telephony provider
             if (isDefaultAppDeliver) {
@@ -97,8 +117,11 @@ class SmsReceiver : BroadcastReceiver() {
 
                 try {
                     val uri = context.contentResolver.insert(Telephony.Sms.Inbox.CONTENT_URI, cv)
-                    uri?.lastPathSegment?.toLongOrNull()?.let { insertedId ->
-                        messageId = insertedId
+                    if (uri != null) {
+                        storedInProvider = true
+                        uri.lastPathSegment?.toLongOrNull()?.let { insertedId ->
+                            messageId = insertedId
+                        }
                     }
 
                     // Query thread ID
@@ -106,12 +129,16 @@ class SmsReceiver : BroadcastReceiver() {
                 } catch (e: Exception) {
                     Log.e(TAG, "Error writing to Telephony provider", e)
                 }
-                shouldWriteMeta = true
             } else {
                 resolveInboxMessageId(context, sender, fullBody, timestamp)?.let { realId ->
                     messageId = realId
-                    shouldWriteMeta = true
+                    storedInProvider = true
                 }
+            }
+
+            if (!storedInProvider) {
+                Log.w(TAG, "Skipping notify/meta; SMS was not stored for ${PhoneNumberKeys.redact(sender)}")
+                continue
             }
 
             // Ensure threadId is resolved
@@ -119,16 +146,14 @@ class SmsReceiver : BroadcastReceiver() {
                 threadId = smsRepository.getOrCreateThreadId(sender)
             }
 
-            if (shouldWriteMeta) {
-                pendingMetaWrites.add(
-                    SpamMetaWrite(
-                        messageId = messageId,
-                        address = sender,
-                        matchedRuleName = filterResult.matchedRuleName,
-                        action = filterResult.action
-                    )
+            pendingMetaWrites.add(
+                SpamMetaWrite(
+                    messageId = messageId,
+                    address = sender,
+                    matchedRuleName = filterResult.matchedRuleName,
+                    action = filterResult.action
                 )
-            }
+            )
 
             // Only notify on SMS_DELIVER (we are default). SMS_RECEIVED is handled by the
             // default SMS app's own notification; we still resolve id and write filter meta.
@@ -214,6 +239,68 @@ class SmsReceiver : BroadcastReceiver() {
             SmsFilterEngine.normalizeAddress(b),
             ignoreCase = true
         )
+    }
+
+    private fun smsAddress(message: AndroidSmsMessage): String {
+        return try {
+            message.displayOriginatingAddress
+        } catch (_: Exception) {
+            null
+        }?.trim().orEmpty().ifBlank {
+            try {
+                message.originatingAddress
+            } catch (_: Exception) {
+                null
+            }?.trim().orEmpty()
+        }
+    }
+
+    private fun smsBody(message: AndroidSmsMessage): String {
+        val display = try {
+            message.displayMessageBody
+        } catch (e: Exception) {
+            Log.w(TAG, "displayMessageBody failed", e)
+            null
+        }
+        if (!display.isNullOrEmpty()) return display
+        return try {
+            message.messageBody
+        } catch (e: Exception) {
+            Log.w(TAG, "messageBody failed", e)
+            null
+        }.orEmpty()
+    }
+
+    private fun AndroidSmsMessage.isClassZero(): Boolean {
+        return try {
+            messageClass == AndroidSmsMessage.MessageClass.CLASS_0
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun AndroidSmsMessage.isTypeZero(): Boolean {
+        return try {
+            (protocolIdentifier and 0xFF) == IncomingSmsPolicy.TYPE_ZERO_PROTOCOL_ID
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun AndroidSmsMessage.isStatusReport(): Boolean {
+        return try {
+            isStatusReportMessage
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun AndroidSmsMessage.isMwiDontStoreMessage(): Boolean {
+        return try {
+            isMwiDontStore || isCphsMwiMessage
+        } catch (_: Exception) {
+            false
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/miss/ga/ui/components/ConversationAvatar.kt
+++ b/app/src/main/java/com/miss/ga/ui/components/ConversationAvatar.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.miss.ga.theme.NonContactAvatarBrush
 import com.miss.ga.theme.getAvatarGradient
+import com.miss.ga.ui.util.senderDisplayName
 
 @Composable
 fun ConversationAvatar(
@@ -28,7 +29,7 @@ fun ConversationAvatar(
     modifier: Modifier = Modifier,
     isContact: Boolean = !contactName.isNullOrBlank()
 ) {
-    val displayName = contactName?.takeIf { it.isNotBlank() } ?: address
+    val displayName = senderDisplayName(contactName, address)
     val initial = displayName.firstOrNull()?.uppercaseChar()?.toString() ?: "#"
     val avatarBrush = if (isContact) getAvatarGradient(address) else NonContactAvatarBrush
     val showLetter = isContact || initial.any { it.isLetter() }

--- a/app/src/main/java/com/miss/ga/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/miss/ga/ui/screens/ChatScreen.kt
@@ -87,6 +87,7 @@ import com.miss.ga.ui.components.ConversationAvatar
 import com.miss.ga.ui.components.MessageBubble
 import com.miss.ga.ui.components.SmsSegmentCounter
 import com.miss.ga.ui.components.SpamMessagePill
+import com.miss.ga.ui.util.senderDisplayName
 import com.miss.ga.ui.viewmodel.ChatViewModel
 import kotlinx.coroutines.launch
 
@@ -221,7 +222,7 @@ fun ChatScreen(
                         Spacer(modifier = Modifier.width(12.dp))
                         Column {
                             Text(
-                                text = state.contactName ?: state.address,
+                                text = senderDisplayName(state.contactName, state.address),
                                 style = MaterialTheme.typography.titleMedium,
                                 fontWeight = FontWeight.Bold
                             )

--- a/app/src/main/java/com/miss/ga/ui/screens/ConversationsScreen.kt
+++ b/app/src/main/java/com/miss/ga/ui/screens/ConversationsScreen.kt
@@ -97,6 +97,7 @@ import com.miss.ga.theme.PillShape
 import com.miss.ga.ui.components.ConversationAvatar
 import com.miss.ga.ui.components.DefaultSmsBanner
 import com.miss.ga.ui.util.SmsDateFormats
+import com.miss.ga.ui.util.senderDisplayName
 import com.miss.ga.ui.viewmodel.ConversationsViewModel
 import com.miss.ga.util.DefaultSmsAppHelper
 import java.util.Locale
@@ -824,7 +825,7 @@ private fun ConversationItem(
     val isSelected by remember(thread.threadId) {
         derivedStateOf { thread.threadId in selectedIds }
     }
-    val displayName = thread.contactName ?: thread.address
+    val displayName = senderDisplayName(thread.contactName, thread.address)
 
     val itemBgColor = if (isSelected) {
         MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.38f)
@@ -1007,7 +1008,7 @@ private fun SearchMessageResultItem(
     searchQuery: String,
     onClick: () -> Unit
 ) {
-    val displayName = item.contactName ?: item.address
+    val displayName = senderDisplayName(item.contactName, item.address)
 
     val primaryColor = MaterialTheme.colorScheme.primary
     val textColor = MaterialTheme.colorScheme.onSurfaceVariant

--- a/app/src/main/java/com/miss/ga/ui/screens/ParticipantSettingsSheet.kt
+++ b/app/src/main/java/com/miss/ga/ui/screens/ParticipantSettingsSheet.kt
@@ -66,6 +66,7 @@ import com.miss.ga.theme.SuccessContainerLight
 import com.miss.ga.theme.SuccessDark
 import com.miss.ga.theme.SuccessLight
 import com.miss.ga.ui.components.ConversationAvatar
+import com.miss.ga.ui.util.senderDisplayName
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -106,7 +107,7 @@ fun ParticipantSettingsSheet(
 
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
-                        text = contactName ?: address,
+                        text = senderDisplayName(contactName, address),
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold
                     )

--- a/app/src/main/java/com/miss/ga/ui/util/SenderLabels.kt
+++ b/app/src/main/java/com/miss/ga/ui/util/SenderLabels.kt
@@ -1,0 +1,15 @@
+package com.miss.ga.ui.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.miss.ga.R
+import com.miss.ga.engine.IncomingSmsPolicy
+
+@Composable
+fun senderDisplayName(contactName: String?, address: String): String {
+    return IncomingSmsPolicy.displayName(
+        contactName = contactName,
+        address = address,
+        unknownLabel = stringResource(R.string.unknown_sender)
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,5 @@
     <string name="open_settings">Open settings</string>
     <string name="retry">Retry</string>
     <string name="send_failed_check_signal">Couldn\'t send message. Check signal and default SMS app.</string>
+    <string name="unknown_sender">Unknown sender</string>
 </resources>

--- a/app/src/test/java/com/miss/ga/IncomingSmsPolicyTest.kt
+++ b/app/src/test/java/com/miss/ga/IncomingSmsPolicyTest.kt
@@ -1,0 +1,155 @@
+package com.miss.ga
+
+import com.miss.ga.engine.IncomingSmsPolicy
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class IncomingSmsPolicyTest {
+
+    @Test
+    fun unknownSenderAliasesAreRecognized() {
+        val aliases = listOf(
+            "",
+            "   ",
+            "Unknown",
+            "UNKNOWN_SENDER",
+            "UNKNOWN_SENDER!",
+            "Unknown sender",
+            "unknown address",
+            "فرستنده ناشناس"
+        )
+        aliases.forEach { alias ->
+            assertTrue("Expected '$alias' to be an unknown-sender alias", IncomingSmsPolicy.isUnknownSenderAlias(alias))
+        }
+        assertFalse(IncomingSmsPolicy.isUnknownSenderAlias("+989121234567"))
+        assertFalse(IncomingSmsPolicy.isUnknownSenderAlias("BankMellat"))
+        assertFalse(IncomingSmsPolicy.isUnknownSenderAlias("10001234"))
+    }
+
+    @Test
+    fun placeholderAndBlankBodiesAreUnusable() {
+        assertTrue(IncomingSmsPolicy.isUnusableBody(""))
+        assertTrue(IncomingSmsPolicy.isUnusableBody("   "))
+        assertTrue(IncomingSmsPolicy.isUnusableBody("NNNN"))
+        assertTrue(IncomingSmsPolicy.isUnusableBody("Message not found"))
+        assertTrue(IncomingSmsPolicy.isUnusableBody("4504: Message not found"))
+        assertFalse(IncomingSmsPolicy.isUnusableBody("رمز پویا: 123456"))
+        assertFalse(IncomingSmsPolicy.isUnusableBody("سلام"))
+    }
+
+    @Test
+    fun dropsGhostUnknownSenderWithEmptyBody() {
+        assertFalse(
+            IncomingSmsPolicy.shouldKeepInInbox(
+                address = "UNKNOWN_SENDER!",
+                body = ""
+            )
+        )
+        assertFalse(
+            IncomingSmsPolicy.shouldKeepInInbox(
+                address = "Unknown",
+                body = "NNNN"
+            )
+        )
+        assertFalse(
+            IncomingSmsPolicy.shouldKeepInInbox(
+                address = "",
+                body = "   "
+            )
+        )
+    }
+
+    @Test
+    fun dropsSilentAndStatusAndMwiMessages() {
+        assertFalse(
+            IncomingSmsPolicy.shouldKeepInInbox(
+                address = "+989121234567",
+                body = "ping",
+                isTypeZero = true
+            )
+        )
+        assertFalse(
+            IncomingSmsPolicy.shouldKeepInInbox(
+                address = "+989121234567",
+                body = "",
+                isStatusReport = true
+            )
+        )
+        assertFalse(
+            IncomingSmsPolicy.shouldKeepInInbox(
+                address = "1000",
+                body = "",
+                isMwiDontStore = true
+            )
+        )
+        assertFalse(
+            IncomingSmsPolicy.shouldKeepInInbox(
+                address = "UNKNOWN_SENDER",
+                body = "",
+                isClassZero = true
+            )
+        )
+    }
+
+    @Test
+    fun keepsRealMessagesIncludingHiddenNumberWithBody() {
+        assertTrue(
+            IncomingSmsPolicy.shouldKeepInInbox(
+                address = "+989121234567",
+                body = "سلام علی جان"
+            )
+        )
+        assertTrue(
+            IncomingSmsPolicy.shouldKeepInInbox(
+                address = "UNKNOWN_SENDER",
+                body = "رمز یکبار مصرف شما: 123456"
+            )
+        )
+        assertTrue(
+            IncomingSmsPolicy.shouldKeepInInbox(
+                address = "BankMellat",
+                body = ""
+            )
+        )
+        assertTrue(
+            IncomingSmsPolicy.shouldKeepInInbox(
+                address = "10001234",
+                body = "تخفیف ویژه",
+                isClassZero = true
+            )
+        )
+    }
+
+    @Test
+    fun ghostConversationHidesEmptyUnknownThreads() {
+        assertTrue(IncomingSmsPolicy.isGhostConversation("UNKNOWN_SENDER!", ""))
+        assertTrue(IncomingSmsPolicy.isGhostConversation("Unknown", "NNNN"))
+        assertFalse(IncomingSmsPolicy.isGhostConversation("UNKNOWN_SENDER", "OTP 1234"))
+        assertFalse(IncomingSmsPolicy.isGhostConversation("+989121234567", ""))
+    }
+
+    @Test
+    fun displayNameUsesUnknownLabelForAliases() {
+        assertEquals(
+            "Unknown sender",
+            IncomingSmsPolicy.displayName(null, "UNKNOWN_SENDER!", "Unknown sender")
+        )
+        assertEquals(
+            "Ali",
+            IncomingSmsPolicy.displayName("Ali", "UNKNOWN_SENDER", "Unknown sender")
+        )
+        assertEquals(
+            "+989121234567",
+            IncomingSmsPolicy.displayName(null, "+989121234567", "Unknown sender")
+        )
+    }
+
+    @Test
+    fun storedAddressUsesStableUnknownTokenForBlankPduAddress() {
+        assertEquals("Unknown", IncomingSmsPolicy.storedAddress(""))
+        assertEquals("UNKNOWN_SENDER!", IncomingSmsPolicy.storedAddress(" UNKNOWN_SENDER! "))
+        assertEquals("+98912", IncomingSmsPolicy.storedAddress("+98912"))
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Misga was treating silent / SIM-toolkit / class-0 PDUs as normal inbox SMS. Those often arrive with originating address `UNKNOWN_SENDER` (or empty) and no usable body, so the app created an empty conversation and fired a notification. Google Messages drops the same PDUs, which is why the thread did not appear there.

## Cause
As the default SMS app, Misga writes every `SMS_DELIVER` into the telephony inbox. Carrier and OEM firmware (especially STK / type-0 / class-0 flash SMS) deliver “ghost” messages that:

- Have address `UNKNOWN_SENDER`, `UNKNOWN_SENDER!`, or blank
- Have an empty body, or a placeholder like `NNNN` / “Message not found”
- Are never stored by Google Messages

Misga also notified even when the inbox insert failed, so tapping the notification opened a chat with no messages.

## Fix
- Drop type-0, status-report, MWI, class-0-empty, and unknown-sender-empty PDUs instead of storing or notifying
- Notify and write filter meta only after a successful inbox insert
- Hide leftover ghost threads from the conversation list
- Show a proper **Unknown sender** label when a hidden-number SMS does have a real body

Real messages, including hidden-number SMS that actually contain text, still go through the existing allowlist/blocklist engine.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6bbf0884-fc13-4eb2-9957-b4424f430b3a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6bbf0884-fc13-4eb2-9957-b4424f430b3a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

